### PR TITLE
feat: add clientHints directive support

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,14 +1,23 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 
+type ClearSiteDataDirective =
+  | "cache"
+  | "clientHints"
+  | "cookies"
+  | "storage"
+  | "executionContexts"
+  | "*";
+
 interface ClearSiteDataOptions {
-  directives?: string[];
+  directives?: ClearSiteDataDirective[];
 }
 
 function getHeaderValueFromOptions({
   directives = ["*"],
 }: Readonly<ClearSiteDataOptions>): string {
-  const VALID_TYPES = new Set([
+  const VALID_TYPES: ReadonlySet<string> = new Set([
     "cache",
+    "clientHints",
     "cookies",
     "storage",
     "executionContexts",

--- a/test.ts
+++ b/test.ts
@@ -6,7 +6,14 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 
 import clearSiteData = require(".");
 
-const ALLOWLIST = ["cache", "cookies", "executionContexts", "storage", "*"];
+const ALLOWLIST = [
+  "cache",
+  "clientHints",
+  "cookies",
+  "executionContexts",
+  "storage",
+  "*",
+] as const;
 
 function app(middleware: ReturnType<typeof clearSiteData>) {
   const result = connect();


### PR DESCRIPTION
## What

Add support for the `"clientHints"` directive in the Clear-Site-Data header.

## Why

I'm building an Express app that handles user privacy preferences. When a user opts out of personalization, I need to clear the Client Hints data stored for the origin (e.g., `Sec-CH-UA-*` hints). Currently `clearsitedata` doesn't support the `"clientHints"` directive, so I have to set the header manually.

The `"clientHints"` directive is [documented on MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data) alongside the other directives. Browser support:

- Chrome 117+
- Edge 117+
- ~73% global coverage

## Changes

- **`index.ts`**: Added `"clientHints"` to `VALID_TYPES` and introduced a `ClearSiteDataDirective` string literal union type for better TypeScript autocomplete (instead of accepting any `string[]`)
- **`test.ts`**: Added `"clientHints"` to the test allowlist

## Tests

All 15 tests pass (14 existing + 1 new for `clientHints`), plus TypeScript, ESLint, and Prettier all pass.